### PR TITLE
add fits.gz extension

### DIFF
--- a/QLFits3/QLFits3-Info.plist
+++ b/QLFits3/QLFits3-Info.plist
@@ -23,6 +23,7 @@
 				<string>arf</string>
 				<string>rsp</string>
 				<string>pi</string>
+				<string>fits.gz</string>
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>QLGenerator</string>
@@ -124,6 +125,7 @@
 					<string>arf</string>
 					<string>rsp</string>
 					<string>pi</string>
+					<string>fits.gz</string>
 				</array>
 				<key>public.mime-type</key>
 				<string>image/fits</string>


### PR DESCRIPTION
Added fits.gz extension. fits already opens zipped fits files, so it
should be able to handle this extension automagically. Patch has not been compiled and verified.
